### PR TITLE
Dev: ProfilingController and new BeanPostProcessor implementation added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Report of Konstantin Mavropulo on lecture "Spring The Ripper" of Evgeny Borisov.
 - Konstantin Mavropulo.
 
 #### Acknowledgments:
-- [lecture of Evgeny Borisov ("Spring The Ripper"](https://www.youtube.com/watch?v=BmBr5diz8WA).
+- [lecture of Evgeny Borisov - "Spring The Ripper"](https://www.youtube.com/watch?v=BmBr5diz8WA).

--- a/src/main/java/com/epam/university/springripper/Main.java
+++ b/src/main/java/com/epam/university/springripper/Main.java
@@ -1,11 +1,16 @@
 package com.epam.university.springripper;
 
+import com.epam.university.springripper.quoters.Quoter;
 import com.epam.university.springripper.quoters.TerminatorQuoter;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 public class Main {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
         ClassPathXmlApplicationContext classPathXmlApplicationContext = new ClassPathXmlApplicationContext("spring/spring-app.xml");
-        classPathXmlApplicationContext.getBean(TerminatorQuoter.class).sayQuote();
+
+        while (true) {
+            Thread.sleep(100);
+            classPathXmlApplicationContext.getBean(Quoter.class).sayQuote();
+        }
     }
 }

--- a/src/main/java/com/epam/university/springripper/quoters/InjectRandomInt.java
+++ b/src/main/java/com/epam/university/springripper/quoters/InjectRandomInt.java
@@ -1,0 +1,11 @@
+package com.epam.university.springripper.quoters;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InjectRandomInt {
+    int min();
+
+    int max();
+}

--- a/src/main/java/com/epam/university/springripper/quoters/InjectRandomIntAnnotationBeanPostProcessor.java
+++ b/src/main/java/com/epam/university/springripper/quoters/InjectRandomIntAnnotationBeanPostProcessor.java
@@ -1,0 +1,33 @@
+package com.epam.university.springripper.quoters;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.util.Random;
+
+public class InjectRandomIntAnnotationBeanPostProcessor implements BeanPostProcessor {
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+
+        Field[] fields = bean.getClass().getDeclaredFields();
+        for (Field field : fields) {
+            InjectRandomInt annotation = field.getAnnotation(InjectRandomInt.class);
+            if (annotation != null) {
+                int min = annotation.min();
+                int max = annotation.max();
+                Random random = new Random();
+                int i = (int) (min + random.nextDouble() * (max - min));
+                field.setAccessible(true);
+                ReflectionUtils.setField(field, bean, i);
+            }
+        }
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+    }
+}

--- a/src/main/java/com/epam/university/springripper/quoters/InjectRandomIntAnnotationBeanPostProcessor.java
+++ b/src/main/java/com/epam/university/springripper/quoters/InjectRandomIntAnnotationBeanPostProcessor.java
@@ -1,16 +1,21 @@
 package com.epam.university.springripper.quoters;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessor;
 import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
 import java.util.Random;
 
 public class InjectRandomIntAnnotationBeanPostProcessor implements BeanPostProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(InjectRandomIntAnnotationBeanPostProcessor.class);
+
     @Override
     public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
-
+        logger.debug("InjectRandomIntAnnotationBeanPostProcessor's postProcessBeforeInitialization(...) started...");
         Field[] fields = bean.getClass().getDeclaredFields();
         for (Field field : fields) {
             InjectRandomInt annotation = field.getAnnotation(InjectRandomInt.class);
@@ -28,6 +33,7 @@ public class InjectRandomIntAnnotationBeanPostProcessor implements BeanPostProce
 
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        logger.debug("InjectRandomIntAnnotationBeanPostProcessor's postProcessAfterInitialization(...) started...");
         return bean;
     }
 }

--- a/src/main/java/com/epam/university/springripper/quoters/Profiling.java
+++ b/src/main/java/com/epam/university/springripper/quoters/Profiling.java
@@ -4,8 +4,5 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
-public @interface InjectRandomInt {
-    int min();
-
-    int max();
+public @interface Profiling {
 }

--- a/src/main/java/com/epam/university/springripper/quoters/ProfilingController.java
+++ b/src/main/java/com/epam/university/springripper/quoters/ProfilingController.java
@@ -1,0 +1,12 @@
+package com.epam.university.springripper.quoters;
+
+import lombok.Getter;
+
+@Getter
+public class ProfilingController implements ProfilingControllerMBean {
+    private boolean enabled;
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/src/main/java/com/epam/university/springripper/quoters/ProfilingControllerMBean.java
+++ b/src/main/java/com/epam/university/springripper/quoters/ProfilingControllerMBean.java
@@ -1,0 +1,5 @@
+package com.epam.university.springripper.quoters;
+
+public interface ProfilingControllerMBean {
+    void setEnabled(boolean enabled);
+}

--- a/src/main/java/com/epam/university/springripper/quoters/ProfilingHandlerBeanPostProcessor.java
+++ b/src/main/java/com/epam/university/springripper/quoters/ProfilingHandlerBeanPostProcessor.java
@@ -1,0 +1,60 @@
+package com.epam.university.springripper.quoters;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+import javax.management.*;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ProfilingHandlerBeanPostProcessor implements BeanPostProcessor {
+    private static final Logger logger = LoggerFactory.getLogger(ProfilingHandlerBeanPostProcessor.class);
+    private Map<String, Class> map = new HashMap<>();
+    private ProfilingController controller = new ProfilingController();
+
+    public ProfilingHandlerBeanPostProcessor() throws MalformedObjectNameException, NotCompliantMBeanException, InstanceAlreadyExistsException, MBeanRegistrationException {
+        MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+        platformMBeanServer.registerMBean(controller, new ObjectName("profiling", "name", "controller"));
+    }
+
+    @Override
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        logger.debug("ProfilingHandlerBeanPostProcessor's postProcessBeforeInitialization(...) started...");
+        Class<?> beanClass = bean.getClass();
+        if (beanClass.isAnnotationPresent(Profiling.class)) {
+            System.out.println(beanClass);
+            map.put(beanName, beanClass);
+        }
+        return bean;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        logger.debug("ProfilingHandlerBeanPostProcessor's postProcessAfterInitialization(...) started...");
+        Class beanClass = map.get(beanName);
+        if (beanClass != null) {
+            return Proxy.newProxyInstance(beanClass.getClassLoader(), beanClass.getInterfaces(), new InvocationHandler() {
+                @Override
+                public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                   // controller.setEnabled(true);
+                    if (controller.isEnabled()) {
+                        logger.debug("Profiling...");
+                        long timeMeasuring = System.nanoTime();
+                        Object methodResult = method.invoke(bean, args);
+                        logger.debug("The duration of the method ~ " + (System.nanoTime() - timeMeasuring));
+                        return methodResult;
+                    } else {
+                        return method.invoke(bean, args);
+                    }
+                }
+            });
+        }
+        return bean;
+    }
+}

--- a/src/main/java/com/epam/university/springripper/quoters/TerminatorQuoter.java
+++ b/src/main/java/com/epam/university/springripper/quoters/TerminatorQuoter.java
@@ -3,8 +3,10 @@ package com.epam.university.springripper.quoters;
 import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
 
+import javax.annotation.PostConstruct;
+
+@Profiling
 @Setter
 public class TerminatorQuoter implements Quoter {
     private static final Logger logger = LoggerFactory.getLogger(TerminatorQuoter.class);
@@ -12,11 +14,21 @@ public class TerminatorQuoter implements Quoter {
     private int repeat;
     private String message;
 
+    //firstly fields are initialized, so the value is null
+    public TerminatorQuoter() {
+        logger.debug("TerminatorQuoter's constructor started...");
+        logger.debug("repeat = " + repeat);
+    }
+
+    @PostConstruct
+    public void init() {
+        logger.debug("TerminatorQuoter's init() started...");
+        logger.debug("repeat" + repeat);
+    }
 
     @Override
     public void sayQuote() {
-        System.out.println("test"+ repeat);
-
+        logger.debug("TerminatorQuoter's sayQuote() started...");
         for (int i = 0; i < repeat; i++) {
             logger.debug("message" + message);
         }

--- a/src/main/java/com/epam/university/springripper/quoters/TerminatorQuoter.java
+++ b/src/main/java/com/epam/university/springripper/quoters/TerminatorQuoter.java
@@ -3,14 +3,22 @@ package com.epam.university.springripper.quoters;
 import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 @Setter
 public class TerminatorQuoter implements Quoter {
     private static final Logger logger = LoggerFactory.getLogger(TerminatorQuoter.class);
+    @InjectRandomInt(min = 2, max = 7)
+    private int repeat;
     private String message;
+
 
     @Override
     public void sayQuote() {
-        logger.debug(message);
+        System.out.println("test"+ repeat);
+
+        for (int i = 0; i < repeat; i++) {
+            logger.debug("message" + message);
+        }
     }
 }

--- a/src/main/resources/spring/spring-app.xml
+++ b/src/main/resources/spring/spring-app.xml
@@ -3,7 +3,9 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
-
+    <!-- id is autocreated by spring for spring -->
+    <bean class="com.epam.university.springripper.quoters.InjectRandomIntAnnotationBeanPostProcessor">
+    </bean>
     <bean id="terminatorQuoter" class="com.epam.university.springripper.quoters.TerminatorQuoter">
         <property name="message" value="I'll be back."/>
     </bean>

--- a/src/main/resources/spring/spring-app.xml
+++ b/src/main/resources/spring/spring-app.xml
@@ -3,9 +3,21 @@
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:annotation-config/>
+
+
+    <!--Can be easily replaced by annotation-config-->
+    <bean class="org.springframework.context.annotation.CommonAnnotationBeanPostProcessor">
+    </bean>
+
     <!-- id is autocreated by spring for spring -->
     <bean class="com.epam.university.springripper.quoters.InjectRandomIntAnnotationBeanPostProcessor">
     </bean>
+
+    <bean class="com.epam.university.springripper.quoters.ProfilingHandlerBeanPostProcessor">
+    </bean>
+
     <bean id="terminatorQuoter" class="com.epam.university.springripper.quoters.TerminatorQuoter">
         <property name="message" value="I'll be back."/>
     </bean>

--- a/target/classes/spring/spring-app.xml
+++ b/target/classes/spring/spring-app.xml
@@ -4,6 +4,20 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
+    <context:annotation-config/>
+
+
+    <!--Can be easily replaced by annotation-config-->
+    <bean class="org.springframework.context.annotation.CommonAnnotationBeanPostProcessor">
+    </bean>
+
+    <!-- id is autocreated by spring for spring -->
+    <bean class="com.epam.university.springripper.quoters.InjectRandomIntAnnotationBeanPostProcessor">
+    </bean>
+
+    <bean class="com.epam.university.springripper.quoters.ProfilingHandlerBeanPostProcessor">
+    </bean>
+
     <bean id="terminatorQuoter" class="com.epam.university.springripper.quoters.TerminatorQuoter">
         <property name="message" value="I'll be back."/>
     </bean>


### PR DESCRIPTION
🏹 Dev:
Profiling annotation interface added to be mark-annotation, ProfilingControllerMbean interface and it's implementation ProfilingController have been added to register the MBean in the MBeanServer and to enable the control in the MBean's menu, where the value of the controller's value can be setted to true of false; ProfilingHandlerBeanPostProcessor implemented the BeanPostProcessor to check the time of method's duration.

Log's added for InjectRandomInt annotation interface and InjectRandomIntAnnotationBeanPostProcessor, them have been added before to implement beforeInitialization's setting the field with getting value from annotation by PostProcessor.